### PR TITLE
Added Communications

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     },
     "dependencies": {
         "@mdi/font": "^7.3.67",
-        "@slipmatio/control-knob": "^0.1.0",
         "pinia": "^2.1.7",
         "roboto-fontface": "^0.10.0",
         "serialport": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@mdi/font':
     specifier: ^7.3.67
     version: 7.3.67
-  '@slipmatio/control-knob':
-    specifier: ^0.1.0
-    version: 0.1.0
   pinia:
     specifier: ^2.1.7
     version: 2.1.7(typescript@5.2.2)(vue@3.3.8)
@@ -771,10 +768,6 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@slipmatio/control-knob@0.1.0:
-    resolution: {integrity: sha512-mIBBLHrlwV6Lbeezy7I5wlxbf7FEG6pRTjf1aD0DBhpjakGOtWAHMVQJ9z0OWd+t/S40hzWE13Yiy8DmGNc3WA==}
     dev: false
 
   /@tootallnate/once@2.0.0:

--- a/src/components/throttle.vue
+++ b/src/components/throttle.vue
@@ -30,9 +30,6 @@
             <v-col cols="10">
               <v-row>
                 <v-col cols="3">
-                  <control-knob
-                    v-if="locomotive.throttleType == ThrottleType.ROTARY"
-                  />
                   <v-slider
                     v-if="locomotive.throttleType == ThrottleType.VERTICAL"
                     direction="vertical"
@@ -69,7 +66,6 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import ControlKnob from '@slipmatio/control-knob';
 import {storeToRefs} from 'pinia';
 import {ref, defineProps} from 'vue';
 import {LocomotiveData, ThrottleType, savedLocosStore} from '../store/locos';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,31 +1,36 @@
-import * as VueRouter from "vue-router";
-import "../assets/styles/reset.css";
+import * as VueRouter from 'vue-router';
+import '../assets/styles/reset.css';
 const routes = [
-  { path: "/", redirect: "/throttles" },
+  {path: '/', redirect: '/throttles'},
   {
-    path: "/throttles",
-    name: "throttles",
-    component: () => import("../views/Throttles.vue"),
+    path: '/throttles',
+    name: 'throttles',
+    component: () => import('../views/Throttles.vue'),
   },
   {
-    path: "/locos",
-    name: "locos",
-    component: () => import("../views/Locos.vue"),
+    path: '/locos',
+    name: 'locos',
+    component: () => import('../views/Locos.vue'),
   },
   {
-    path: "/functions",
-    name: "functions",
-    component: () => import("../views/Functions.vue"),
+    path: '/functions',
+    name: 'functions',
+    component: () => import('../views/Functions.vue'),
   },
   {
-    path: "/settings",
-    name: "settings",
-    component: () => import("../views/Settings.vue"),
+    path: '/communications',
+    name: 'communications',
+    component: () => import('../views/Communications.vue'),
   },
   {
-    path: "/layout",
-    name: "layout",
-    component: () => import("../views/Layout.vue"),
+    path: '/settings',
+    name: 'settings',
+    component: () => import('../views/Settings.vue'),
+  },
+  {
+    path: '/layout',
+    name: 'layout',
+    component: () => import('../views/Layout.vue'),
   },
 ];
 

--- a/src/store/communications.ts
+++ b/src/store/communications.ts
@@ -1,0 +1,46 @@
+import {defineStore} from 'pinia';
+
+export type LogItemKind = 'sent' | 'received';
+export type LogItem = {
+    message: string
+    kind: LogItemKind
+    timestamps: {
+        createdAt: Date
+    }
+}
+
+export type Logs = LogItem[]
+
+type CommunicationsState = {
+    logs: Logs
+}
+
+export const useCommunicationsStore = defineStore('communications', {
+  state: (): CommunicationsState => {
+    return {
+      logs: [],
+    };
+  },
+  getters: {
+    sentLogs: ({logs}): Logs => {
+      return logs.filter((logItem) => logItem.kind === 'sent');
+    },
+    receivedLogs: ({logs}): Logs => {
+      return logs.filter((logItem) => logItem.kind === 'received');
+    },
+  },
+  actions: {
+    sendMessage(message: string): void {
+      const newLogItem: LogItem = {message, timestamps: {createdAt: new Date}, kind: 'sent'};
+      this.addLogItem(newLogItem);
+    },
+    fakeReadMessage(message: string): void {
+      const newLogItem: LogItem = {message, timestamps: {createdAt: new Date}, kind: 'received'};
+      this.addLogItem(newLogItem);
+    },
+    addLogItem(logItem: LogItem): void {
+      const newLogItem = {...logItem};
+      this.logs = [newLogItem, ...this.logs];
+    },
+  },
+});

--- a/src/store/global.ts
+++ b/src/store/global.ts
@@ -21,6 +21,7 @@ export const useGlobalStore = defineStore("global", {
         { icon: "mdi:remote", to: "throttles", title: "Throttles" },
         { icon: "mdi:train", to: "locos", title: "Saved Locomotives" },
         { icon: "mdi:function", to: "functions", title: "Mapped Functions" },
+        { icon: "mdi:envelope", to: "communications", title: "Communications" },
         { icon: "mdi:cog", to: "settings", title: "Settings" },
       ],
     };

--- a/src/views/Communications.vue
+++ b/src/views/Communications.vue
@@ -6,9 +6,9 @@ export default {
 
 <script setup lang="ts">
 import {ref} from 'vue';
-import CommunicationsLogs from '@/views/communications/Logs.vue';
-import CommunicationsSendForm from '@/views/communications/SendForm.vue';
-import CommunicationsFakeReadForm from '@/views/communications/FakeReadForm.vue';
+import CommunicationsFakeReadForm from "@/views/communications/FakeReadForm.vue";
+import CommunicationsSendForm from "@/views/communications/SendForm.vue";
+import CommunicationsLogs from "@/views/communications/Logs.vue";
 
 const tab = ref('general');
 

--- a/src/views/Communications.vue
+++ b/src/views/Communications.vue
@@ -1,0 +1,56 @@
+<script lang="ts">
+export default {
+  name: 'CommunicationsView',
+};
+</script>
+
+<script setup lang="ts">
+import {ref} from 'vue';
+import CommunicationsLogs from '@/views/communications/Logs.vue';
+import CommunicationsSendForm from '@/views/communications/SendForm.vue';
+import CommunicationsFakeReadForm from '@/views/communications/FakeReadForm.vue';
+
+const tab = ref('general');
+
+</script>
+
+<template>
+  <v-container>
+    <v-toolbar color="primary" class="text-center">
+      <v-toolbar-title>Communications</v-toolbar-title>
+    </v-toolbar>
+
+    <v-tabs v-model="tab" color="primary">
+      <v-tab value="log">
+        <v-icon start icon="mdi:format-list-bulleted"/>
+        Log
+      </v-tab>
+      <v-tab value="send">
+        <v-icon start icon="mdi:call-made"/>
+        Send
+      </v-tab>
+      <v-tab value="fakeRead">
+        <v-icon start icon="mdi:call-received"/>
+        Fake Read
+      </v-tab>
+    </v-tabs>
+
+    <v-window v-model="tab">
+      <v-window-item value="log">
+        <v-container>
+          <CommunicationsLogs/>
+        </v-container>
+      </v-window-item>
+      <v-window-item value="send">
+        <v-container>
+          <CommunicationsSendForm/>
+        </v-container>
+      </v-window-item>
+      <v-window-item value="fakeRead">
+        <v-container>
+          <CommunicationsFakeReadForm/>
+        </v-container>
+      </v-window-item>
+    </v-window>
+  </v-container>
+</template>

--- a/src/views/Layout.vue
+++ b/src/views/Layout.vue
@@ -52,7 +52,7 @@ function animate() {
 }
 
 onMounted(() => {
-  renderer.domElement = layoutDisplay;
+  // renderer.domElement = layoutDisplay;
   animate();
 });
 </script>

--- a/src/views/communications/FakeReadForm.vue
+++ b/src/views/communications/FakeReadForm.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import {useCommunicationsStore} from '@/store/communications';
+import {useCommunicationsStore} from '../../store/communications';
 import {ref} from 'vue';
 
 const communicationsStore = useCommunicationsStore();

--- a/src/views/communications/FakeReadForm.vue
+++ b/src/views/communications/FakeReadForm.vue
@@ -1,0 +1,33 @@
+<script lang="ts">
+export default {
+  name: 'CommunicationsFakeReadForm',
+};
+</script>
+
+<script setup lang="ts">
+import {useCommunicationsStore} from '@/store/communications';
+import {ref} from 'vue';
+
+const communicationsStore = useCommunicationsStore();
+const formMessage = ref<string>('');
+
+function handleFormSubmit(message: string) {
+  communicationsStore.fakeReadMessage(message);
+  formMessage.value = '';
+}
+
+</script>
+
+<template>
+  <p class="text-overline">
+    Simulates commands received from the Command Station
+  </p>
+
+  <v-form @submit.prevent="handleFormSubmit(formMessage)">
+    <v-text-field v-model="formMessage" label="Read Command" required/>
+
+    <div>
+      <v-btn type="submit" text="Fake Read"/>
+    </div>
+  </v-form>
+</template>

--- a/src/views/communications/Logs.vue
+++ b/src/views/communications/Logs.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import {useCommunicationsStore} from '@/store/communications';
+import {useCommunicationsStore} from '../../store/communications';
 import {storeToRefs} from 'pinia';
 import {computed, ComputedRef} from 'vue';
 

--- a/src/views/communications/Logs.vue
+++ b/src/views/communications/Logs.vue
@@ -1,0 +1,34 @@
+<script lang="ts">
+export default {
+  name: 'CommunicationsLogs',
+};
+</script>
+
+<script setup lang="ts">
+import {useCommunicationsStore} from '@/store/communications';
+import {storeToRefs} from 'pinia';
+import {computed, ComputedRef} from 'vue';
+
+const communicationsStore = useCommunicationsStore();
+const isEmpty: ComputedRef<boolean> = computed(() => communicationsStore.logs.length === 0);
+const {logs} = storeToRefs(communicationsStore);
+
+</script>
+
+<template>
+  <p v-show="isEmpty" class="text-overline">
+    Waiting for communications...
+  </p>
+
+  <v-list v-show="!isEmpty" density="compact">
+    <v-list-item v-for="(logItem, index) in logs" :key="index" color="primary">
+      <template #prepend>
+        <v-icon v-show="logItem.kind === 'sent'" icon="mdi:call-made"/>
+        <v-icon v-show="logItem.kind === 'received'" icon="mdi:call-received"/>
+      </template>
+
+      <v-list-item-title v-text="logItem.message" />
+      <v-list-item-subtitle v-text="logItem.timestamps.createdAt.toLocaleString()"/>
+    </v-list-item>
+  </v-list>
+</template>

--- a/src/views/communications/SendForm.vue
+++ b/src/views/communications/SendForm.vue
@@ -1,0 +1,33 @@
+<script lang="ts">
+export default {
+  name: 'CommunicationsSendForm',
+};
+</script>
+
+<script setup lang="ts">
+import {useCommunicationsStore} from '@/store/communications';
+import {ref} from 'vue';
+
+const communicationsStore = useCommunicationsStore();
+const formMessage = ref<string>('');
+
+function handleFormSubmit(message: string) {
+  communicationsStore.sendMessage(message);
+  formMessage.value = '';
+}
+
+</script>
+
+<template>
+  <p class="text-overline">
+    Send commands directly to the Command Station
+  </p>
+
+  <v-form @submit.prevent="handleFormSubmit(formMessage)">
+    <v-text-field v-model="formMessage" label="Command" required/>
+
+    <div>
+      <v-btn type="submit" text="Send"/>
+    </div>
+  </v-form>
+</template>

--- a/src/views/communications/SendForm.vue
+++ b/src/views/communications/SendForm.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import {useCommunicationsStore} from '@/store/communications';
+import {useCommunicationsStore} from '../../store/communications';
 import {ref} from 'vue';
 
 const communicationsStore = useCommunicationsStore();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
### Added a Comms log
To display all communications sent and received

### Added a Send Comms form
To send communications (this only adds to the log for now)

### Added a Fake Read form
To simulate a message being received from the Command Station (message added to logs as a "received" message)

### Screenshots
| page |  |
|---|---|
| Empty logs | ![Screenshot 2023-12-07 at 07-38-42 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/94b0c0c5-c7cb-40ea-b870-f1fc4a3bee48) |
| Send form | ![Screenshot 2023-12-07 at 07-39-01 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/4d035c2e-b390-422b-8789-9633e09fd299) |
| Send form (user-input) | ![Screenshot 2023-12-07 at 07-40-12 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/da8d1ffe-f479-496e-b7a6-840d9560c845) |
| Logs (sent items) | ![Screenshot 2023-12-07 at 07-40-50 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/92f07176-b56d-41b5-a494-e34afb4ffb83) |
| Fake read form | ![Screenshot 2023-12-07 at 07-39-11 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/2f0f05c7-fea6-4ee5-b33b-418f72f78512) |
| Fake read form (user-input) | ![Screenshot 2023-12-07 at 07-41-32 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/d9c8ae06-8e1d-40d0-8d9c-0c7e3b5e1b28) |
| Logs (populated) | ![Screenshot 2023-12-07 at 07-41-41 Vuetify 3](https://github.com/DCC-EX/EX-WebThrottle2/assets/8854356/8728b9f3-cc36-4107-8440-f70f36468080)  |